### PR TITLE
-webkit-border-top-left-radius incorrectly mapped to top-RIGHT unprefixed property

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -323,7 +323,7 @@ be performant.)</p>
       <td><code><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-bottom-right-radius">border-bottom-right-radius</a></code>
      <tr>
       <td><code><dfn data-dfn-type="dfn" data-noexport="" id="-webkit-border-top-left-radius" type="property">-webkit-border-top-left-radius<a class="self-link" href="#-webkit-border-top-left-radius"></a></dfn></code>
-      <td><code><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-top-right-radius">border-top-right-radius</a></code>
+      <td><code><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-top-left-radius">border-top-left-radius</a></code>
      <tr>
       <td><code><dfn data-dfn-type="dfn" data-noexport="" id="-webkit-border-top-right-radius" type="property">-webkit-border-top-right-radius<a class="self-link" href="#-webkit-border-top-right-radius"></a></dfn></code>
       <td><code><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#border-top-right-radius">border-top-right-radius</a></code>


### PR DESCRIPTION
This fix it by mapping it to border-top-left-radius (as implemented in Firefox)