### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -13,6 +13,7 @@ Logo: https://resources.whatwg.org/logo-compat.svg
 !Commits: <a href="https://github.com/whatwg/compat/commits">GitHub whatwg/compat/commits</a>
 !Commits: [SNAPSHOT-LINK]
 !Commits: <a href="https://twitter.com/compatstandard">@compatstandard</a>
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/compat>web-platform-tests compat/</a>
 !Translation (non-normative): <a href="https://triple-underscore.github.io/compat-ja.html">日本語</a>
 Indent: 2
 Boilerplate: omit conformance


### PR DESCRIPTION
A few other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://xhr.spec.whatwg.org/

Unlike those specs, there's no label in wpt for compat, so no
"ongoing work" link was added.