### PR TITLE
Meta: update the URL for the common deploy.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - DEPLOY_USER="annevankesteren"
 
 script:
-  - curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+  - make deploy
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ local: compatibility.bs
 
 remote: compatibility.bs
 	curl https://api.csswg.org/bikeshed/ -f -F file=@compatibility.bs > compatibility.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
+
+deploy: compatibility.bs
+	curl --remote-name --fail https://raw.githubusercontent.com/whatwg/common-build/master/deploy.sh && bash ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ running `make remote`.
 If you want to do a complete "local deploy" including commit and/or branch snapshots, run
 
 ```
-./deploy.sh --local
+make deploy
 ```
 
 Run the following steps to enable fancy-mode (which will run `make` every time `compatibility.bs` is changed on the filesystem).


### PR DESCRIPTION
Also fix the README.md, the local deploy.sh is gone.