### PR TITLE
Meta: Markup fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Note that this still requires access to the network.
 
 Run the following steps to enable fancy-mode (which will run `make` every time `compatibility.bs` is changed on the filesystem).
 
-Step 0. Install Node.js and npm
-Step 1: Run the following commands
+* Step 0. Install Node.js and npm
+* Step 1: Run the following commands
 
 ```
 npm install


### PR DESCRIPTION
Currently, the linefeed is not rendered as a newline on GitHub.

I'm also OK with changing it to an ordered list in Markdown syntax if it's preferred (although it won't be 0-indexed any more).