### PR TITLE
Meta: reference whatwg/meta resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - EXTRA_FILES="*.png"
 
 script:
-  - curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+  - make deploy
 
 branches:
   only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see the [contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see the [contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).
+Please see the [WHATWG Contributor Guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
 ## Contribute
 
 In short, change `compatibility.bs` and submit your patch, with a
-[good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages). Consider
-reading through the [WHATWG FAQ](https://wiki.whatwg.org/wiki/FAQ) if you are new here.
+[good commit message](https://github.com/whatwg/meta/blob/master/COMMITTING.md). Consider
+reading through the [WHATWG FAQ](https://whatwg.org/faq) if you are new here.
 
 Please add your name to the Acknowledgments section in your first pull request, even for trivial
 fixes. The names are sorted lexicographically.
@@ -33,5 +33,3 @@ make deploy
 Note that this still requires access to the network.
 
 Run `bikeshed watch` to enable fancy-mode (which sets up a watcher and auto-rebuilds the spec every time it changes).
-
-Contributions are welcome, so long as you agree to the [CC0 license](LICENSE). :rainbow: :stars:


### PR DESCRIPTION
Also remove leftover CC0 reference.

Helps with https://github.com/whatwg/meta/issues/65.