### PR TITLE
Fix <dfn> of -webkit-flex

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -525,7 +525,7 @@ The following <code>-webkit-</code> <a>vendor prefixed</a> keywords must be supp
       <td><code>''flex''</code></td>
     </tr>
     <tr>
-      <td><code><dfn value lt="-webkit-flex-valdef">-webkit-flex</dfn></code></td>
+      <td><code><dfn value id="valdef-flex--webkit-flex-valdef">-webkit-flex</dfn></code></td>
       <td><code>''flex''</code></td>
     </tr>
     <tr>

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -308,7 +308,7 @@ The following <code>-webkit-</code> <a>vendor prefixed</a> properties must be su
       <td><code>'box-sizing'</code></td>
     </tr>
     <tr>
-      <td><code><dfn property lt="-webkit-flex-propdef">-webkit-flex</dfn></code></td>
+      <td><code><dfn property id="propdef--webkit-flex-propdef">-webkit-flex</dfn></code></td>
       <td><code>'flex'</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
This maintains the id it had, but fixes the link text to be the expected name of the property

[editorial]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/134.html" title="Last updated on Dec 16, 2020, 5:08 PM UTC (0505050)">Preview</a> | <a href="https://whatpr.org/compat/134/c0f5a5a...0505050.html" title="Last updated on Dec 16, 2020, 5:08 PM UTC (0505050)">Diff</a>