### PR TITLE
Fixes #148 - Declare img width and height using attributes

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -702,7 +702,7 @@ properties to achieve white text with a black stroked text effect.
 The element <pre>&ltp class="stroked-text-longhand"&gt;Serious typography&lt;/p&gt;</pre> would be
 rendered as follows:
 
-<img style="width: 381px;height: 116px;" src="stroked-text.png" alt="image of stroked text">
+<img width="381" height="116" src="stroked-text.png" alt="image of stroked text">
 </div>
 
 <h3 id="css-property-values">CSS Property values</h3>


### PR DESCRIPTION
(not inline style)

In theory bikeshed should like this more.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/149.html" title="Last updated on Jun 2, 2021, 5:21 PM UTC (96e0585)">Preview</a> | <a href="https://whatpr.org/compat/149/c66385f...96e0585.html" title="Last updated on Jun 2, 2021, 5:21 PM UTC (96e0585)">Diff</a>