### PR TITLE
Editorial: Add leading dash to`-webkit-`

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -73,9 +73,9 @@ spec:infra; type:dfn; text:user agent
 
 There exists an increasingly large corpus of web content that depends on web browsers supporting a
 number of specific vendor CSS properties and DOM APIs for functionality or layout.
-This holds especially true for mobile-optimized web content, which is highly dependent on <code>webkit</code>-prefixed properties.
+This holds especially true for mobile-optimized web content, which is highly dependent on <code>-webkit-</code>-prefixed properties.
 
-This specification aims to describe the minimal set of <code>webkit</code>-prefixed CSS properties
+This specification aims to describe the minimal set of <code>-webkit-</code>-prefixed CSS properties
 and DOM APIs that user agents are required to support for web compatibility, which aren't
 specified elsewhere.
 


### PR DESCRIPTION
As used universally everywhere else in the spec.

<!--
Thank you for contributing to the Compatibility Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/176.html" title="Last updated on Feb 3, 2022, 1:43 AM UTC (4d4e8af)">Preview</a> | <a href="https://whatpr.org/compat/176/ec26d28...4d4e8af.html" title="Last updated on Feb 3, 2022, 1:43 AM UTC (4d4e8af)">Diff</a>