### PR TITLE
Meta: fix #214 - Removes the broken ref to animation type

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -36,9 +36,6 @@ urlPrefix: https://www.w3.org/TR/2011/WD-css3-images-20110217/; spec: css3-image
 urlPrefix: https://drafts.csswg.org/css-backgrounds-4/
   type: dfn
     text: background-clip; url: #propdef-background-clip
-urlPrefix: https://drafts.csswg.org/css-transitions/
-  type: dfn
-    text: color; url: #animtype-color
 urlPrefix: https://drafts.fxtf.org/css-masking-1/
   type: dfn
     text: clipping path; url: #clipping-path
@@ -600,7 +597,7 @@ Inherited: yes
 Computed value: an RGBA color
 Percentages: N/A
 Media: visual
-Animation type: as <a>color</a>
+Animation type: by computed value type
 </pre>
 
 The '-webkit-text-fill-color' property defines the foreground [=fill=] color of an element's text
@@ -637,7 +634,7 @@ Inherited: yes
 Computed value: an RGBA color
 Percentages: N/A
 Media: visual
-Animation type: as <a>color</a>
+Animation type: by computed value type
 </pre>
 
 The '-webkit-text-stroke-color' property specifies a [=stroke=] color for an element's text.


### PR DESCRIPTION
Fix #214.  See the comment about  the broken reference.
Hmm Should I put editorial in there?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/215.html" title="Last updated on Oct 14, 2022, 1:14 AM UTC (c765c7f)">Preview</a> | <a href="https://whatpr.org/compat/215/dd67fc2...c765c7f.html" title="Last updated on Oct 14, 2022, 1:14 AM UTC (c765c7f)">Diff</a>