### PR TITLE
Define -webkit-text-stroke sub-properties

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -62,6 +62,7 @@ spec:css-flexbox-1; type:value; text:inline-flex
 spec:filter-effects-1; type:property; text:filter
 spec:infra; type:dfn; text:user agent
 spec:svg2; type:dfn; text:fill
+spec:svg2; type:dfn; text:stroke
 </pre>
 
 <!-- Commented out until we know what the heck to put here:

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -673,7 +673,9 @@ Media: visual
 Animation type: See individual properties
 </pre>
 
-The '-webkit-text-stroke' property is a shorthand property for setting the [=stroke=] width and
+The '-webkit-text-stroke' property is a shorthand property
+for the '-webkit-text-stroke-width' and '-webkit-text-stroke-color' properties,
+for setting the [=stroke=] width and
 [=stroke=] color of an element's text.
 
 <div class="example" id="example-webkit-text-stroke">

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -59,6 +59,7 @@ spec:css-animations-1; type:property; text:animation-delay
 spec:css-conditional-3; type:at-rule; text:@media
 spec:css-display-3; type:value; for:display; text:flex
 spec:css-flexbox-1; type:value; text:inline-flex
+spec:css-syntax-3; type:dfn; text:invalid
 spec:filter-effects-1; type:property; text:filter
 spec:infra; type:dfn; text:user agent
 spec:svg2; type:dfn; text:fill


### PR DESCRIPTION
This an editorial change.

*The <shorthand-name> property is a shorthand for ...* is a canonical sentence often used in CSS specs, which is followed by the names of its sub-properties, therefore the current text is ambiguous because it links to the SVG 2 spec and suggests that this spec defines its sub-properties.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/232.html" title="Last updated on Feb 27, 2023, 4:14 PM UTC (69f6e6e)">Preview</a> | <a href="https://whatpr.org/compat/232/e23a6e7...69f6e6e.html" title="Last updated on Feb 27, 2023, 4:14 PM UTC (69f6e6e)">Diff</a>