### PR TITLE
Meta: Add 'box-shadow' and 'border-radius' to link-defaults

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -56,6 +56,8 @@ urlPrefix: https://drafts.csswg.org/css-values-3/
 
 <pre class=link-defaults>
 spec:css-animations-1; type:property; text:animation-delay
+spec:css-borders-4; type:property; text:box-shadow
+spec:css-borders-4; type:property; text:border-radius
 spec:css-conditional-3; type:at-rule; text:@media
 spec:css-display-3; type:value; for:display; text:flex
 spec:css-flexbox-1; type:value; text:inline-flex


### PR DESCRIPTION
Fixes #250


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/251.html" title="Last updated on Sep 27, 2023, 5:06 PM UTC (91e628b)">Preview</a> | <a href="https://whatpr.org/compat/251/5f87ba7...91e628b.html" title="Last updated on Sep 27, 2023, 5:06 PM UTC (91e628b)">Diff</a>