### PR TITLE
Add Third-Party Cookie Deprecation Heuristics to Web Compat

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -859,13 +859,37 @@ Note: 15 minutes is a reasonable [=redirect heuristic grant duration=] value.
 
 <h3 id="sa-heuristics-grant">Storage Access Grant</h3>
 
+The 
+
 <div algorithm>
+
+Define a [=powerful feature=] identified by the [=powerful feature/name=]
+"storage-access-heuristics", with the following [=powerful feature/aspects=]:
+
+<dfn>permission key type</dfn>
+A [=permission key=] of the "storage-access-heuristics" feature is a [=tuple=] consisting
+of a [=host=] <dfn property>top-level</dfn> and a [=host=] <dfn property>requester</dfn>.
 
 To <dfn>grant access for heuristics</dfn> given a [=host=] |host|, [=host=]
 |firstPartyHost|, and [=duration=] |duration|, perform the following steps:
 
-1. TODO
-1. |host|, |firstPartyHost|, |duration|
+1. Let |key| be a [=permission key=] with |top-level| set to |firstPartyHost|
+    and |host| set to |requester.
+1. Queue a task on the [=current settings object=]'s [=responsible event loop=] to:
+    1. [=Set a permission store entry=] with:
+      <dl>
+          <dt><var ignore>descriptor</var></dt>
+          <dd>"storage-access-heuristics"</dd>
+          <dt><var ignore>key</var></dt>
+          <dd>|key|</dd>
+          <dt><var ignore>current state</var></dt>
+          <dd>"granted"</dd>
+      </dl>
+    2. Set the new permission's [=permission/lifetime=] to |lifetime|.
+
+Note: This algorithm is based on [=request permission to use=], except for the following key differences:
+- It sets a dynamic permission [=permission/lifetime=].
+- It generates a [=permission key=] independently of the [=current settings object=].
 
 </div>
 
@@ -924,7 +948,38 @@ perform the following steps:
 
 <h3 id="sa-heuristics-redirect">Redirect Heuristic</h3>
 
-TODO
+Insert the following steps in the <a spec="html">load a document</a> algorithm,
+before Step 5, "Return null", which is the point that the [=document=] is loaded.
+
+1. Run [=detect a popup heuristic=] given
+    <var ignore>navigable</var> and <var ignore>response</var>'s <var ignore>URL list</var>.
+
+<div algorithm>
+
+To <dfn>detect a popup heuristic</dfn> given a [=navigable=] |navigable|
+and a [=list=] of [=URLs=] |URLs|, perform the following steps:
+
+1. Let |firstPartyOrigin| be |topDocument|'s [=Document/origin=].
+1. If |firstPartyOrigin| is an [=opaque origin=] then abort these steps.
+1. Let |firstPartySite| be the result of running [=obtain a site=] given |firstPartyOrigin|.
+1. Let |firstPartyHost| be |firstPartySite|'s [=host=].
+1. [=list/For each=] |bounceUrl| in |URLs|:
+  1. Let |bounceSite| be the result of running [=obtain a site=] given |origin|.
+  1. Let |bounceHost| be |bounceSite|'s [=host=].
+  1. If |bounceHost| [=host/equals=] |host|, [=iteration/continue=].
+  1. TODO: Check current interaction
+  1. TODO: Check ABA flow
+  1. [=Grant access for heuristics=] given:
+    <dl>
+        <dt><var ignore>host</var></dt>
+        <dd>|bounceHost|</dd>
+        <dt><var ignore>firstPartyHost</var></dt>
+        <dd>|firstPartyHost|<dd>
+        <dt><var ignore>duration</var></dt>
+        <dd>[=redirect heuristic grant duration=]</dd>
+    </dl>
+
+</div>
 
 <h2 id="ua-string-section">The User-Agent String</h2>
 

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -64,6 +64,7 @@ spec:css-flexbox-1; type:value; text:inline-flex
 spec:css-syntax-3; type:dfn; text:invalid
 spec:filter-effects-1; type:property; text:filter
 spec:html; type:dfn; for:/; text:top-level traversable
+spec:infra; type:dfn; text:list
 spec:infra; type:dfn; text:user agent
 spec:svg2; type:dfn; text:fill
 spec:svg2; type:dfn; text:stroke
@@ -859,22 +860,19 @@ Note: 15 minutes is a reasonable [=redirect heuristic grant duration=] value.
 
 <h3 id="sa-heuristics-grant">Storage Access Grant</h3>
 
-The 
-
-<div algorithm>
-
 Define a [=powerful feature=] identified by the [=powerful feature/name=]
-"storage-access-heuristics", with the following [=powerful feature/aspects=]:
+"storage-access-heuristics", with the following <dfn>permission key type</dfn>:
 
-<dfn>permission key type</dfn>
 A [=permission key=] of the "storage-access-heuristics" feature is a [=tuple=] consisting
 of a [=host=] <dfn property>top-level</dfn> and a [=host=] <dfn property>requester</dfn>.
+
+<div algorithm>
 
 To <dfn>grant access for heuristics</dfn> given a [=host=] |host|, [=host=]
 |firstPartyHost|, and [=duration=] |duration|, perform the following steps:
 
-1. Let |key| be a [=permission key=] with |top-level| set to |firstPartyHost|
-    and |host| set to |requester.
+1. Let |key| be a [=permission key=] with <var ignore>top-level</var> set to |firstPartyHost|
+    and <var ignore>requester</var> set to |host|.
 1. Queue a task on the [=current settings object=]'s [=responsible event loop=] to:
     1. [=Set a permission store entry=] with:
       <dl>
@@ -885,33 +883,16 @@ To <dfn>grant access for heuristics</dfn> given a [=host=] |host|, [=host=]
           <dt><var ignore>current state</var></dt>
           <dd>"granted"</dd>
       </dl>
-    2. Set the new permission's [=permission/lifetime=] to |lifetime|.
+    2. Set the new permission's [=permission/lifetime=] to |duration|.
 
-Note: This algorithm is based on [=request permission to use=], except for the following key differences:
+<div class=note>
+This algorithm is based on [=request permission to use=], except for the following key differences:
 - It sets a dynamic permission [=permission/lifetime=].
-- It generates a [=permission key=] independently of the [=current settings object=].
+- It generates a [=permission key=] independently of the [=current settings object=].</div>
 
 </div>
 
 <h3 id="sa-heuristics-popup">Popup Heuristic</h3>
-
-Each [=top-level traversable=] has an associated
-<dfn for="top-level traversable">popup heuristic initiator host</dfn> which
-is a [=host=] or null. This stores the [=host=] of the <var ignore>opener</var> if
-[=top-level traversable=] is considered an eligible popup for the heuristic.
-
-Append the following steps to the <a spec="html">create a new top-level traversable</a>
-algorithm:
-1. TODO: Check opener access
-1. TODO: Check initiator iframe
-1. Let |popup heuristic initiator origin| be the <var ignore>opener</var>'s
-    [=browsing context/top-level traversable=]'s [=navigable/active document=]'s
-    [=Document/origin=].
-1. If |popup heuristic initiator origin| is an [=opaque origin=] then abort these steps.
-1. Let |popup heuristic initiator site| be the result of running [=obtain a site=] given
-    |popup heuristic initiator origin|.
-1. Set the [=top-level traversable=]'s [=popup heuristic initiator host=] to 
-    |popup heuristic initiator site|'s [=host=].
 
 Append the following steps to the <a spec="html">activation notification</a>
 steps in the [[HTML#user-activation-processing-model|user activation processing
@@ -924,10 +905,11 @@ model]]:
 To <dfn>detect a popup heuristic</dfn> given a [=Document=] |document|,
 perform the following steps:
 
+1. Let |browsingContext| be |document|'s [=Document/browsing context=].
+1. If |browsingContext|'s <var ignore>is popup</var> is false, then abort these steps.
+1. If |browsingContext|'s <var ignore>opener origin at creation</var> is null, then abort these steps.
 1. Let |navigable| be |document|'s [=node navigable=].
 1. If |navigable| is null, then abort these steps.
-1. If |navigable|'s [=popup heuristic initiator host=] is null,
-    then abort these steps.
 1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
     [=navigable/active document=].
 1. Let |origin| be |topDocument|'s [=Document/origin=].
@@ -939,7 +921,7 @@ perform the following steps:
         <dt><var ignore>host</var></dt>
         <dd>|host|</dd>
         <dt><var ignore>firstPartyHost</var></dt>
-        <dd>|navigable|'s [=popup heuristic initiator host=]</dd>
+        <dd>|browsingContext|'s <var ignore>opener origin at creation=</var></dd>
         <dt><var ignore>duration</var></dt>
         <dd>[=popup heuristic grant duration=]</dd>
     </dl>
@@ -951,24 +933,26 @@ perform the following steps:
 Insert the following steps in the <a spec="html">load a document</a> algorithm,
 before Step 5, "Return null", which is the point that the [=document=] is loaded.
 
-1. Run [=detect a popup heuristic=] given
-    <var ignore>navigable</var> and <var ignore>response</var>'s <var ignore>URL list</var>.
+1. Run [=detect a redirect heuristic=] given <var ignore>navigable</var>.
 
 <div algorithm>
 
-To <dfn>detect a popup heuristic</dfn> given a [=navigable=] |navigable|
-and a [=list=] of [=URLs=] |URLs|, perform the following steps:
+To <dfn>detect a redirect heuristic</dfn> given a navigable |navigable|,
+perform the following steps:
 
+1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
+    [=navigable/active document=].
 1. Let |firstPartyOrigin| be |topDocument|'s [=Document/origin=].
 1. If |firstPartyOrigin| is an [=opaque origin=] then abort these steps.
 1. Let |firstPartySite| be the result of running [=obtain a site=] given |firstPartyOrigin|.
 1. Let |firstPartyHost| be |firstPartySite|'s [=host=].
-1. [=list/For each=] |bounceUrl| in |URLs|:
-  1. Let |bounceSite| be the result of running [=obtain a site=] given |origin|.
+1. Let |bounceTrackingRecord| be |navigable|'s [=top-level traversable=]'s <var ignore>bounce tracking record</var>.
+1. [=list/For each=] |bounceUrl| in |bounceTrackingRecord|'s <var ignore>bounce set</var>:
+  1. Let |bounceSite| be the result of running [=obtain a site=] given |bounceUrl|.
   1. Let |bounceHost| be |bounceSite|'s [=host=].
-  1. If |bounceHost| [=host/equals=] |host|, [=iteration/continue=].
-  1. TODO: Check current interaction
-  1. TODO: Check ABA flow
+  1. If |bounceHost| [=host/equals=] |firstPartyHost|, [=iteration/continue=].
+  <!-- TODO: check if |bounceUrl| has a transient activation. This will require patching bounce tracking record. -->
+  <!-- TODO: check A-B-A user flow. This will require traversing the navigable's history. -->
   1. [=Grant access for heuristics=] given:
     <dl>
         <dt><var ignore>host</var></dt>

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -63,9 +63,11 @@ spec:css-display-3; type:value; for:display; text:flex
 spec:css-flexbox-1; type:value; text:inline-flex
 spec:css-syntax-3; type:dfn; text:invalid
 spec:filter-effects-1; type:property; text:filter
+spec:html; type:dfn; for:/; text:top-level traversable
 spec:infra; type:dfn; text:user agent
 spec:svg2; type:dfn; text:fill
 spec:svg2; type:dfn; text:stroke
+spec:url; type:dfn; for:url; text:host
 </pre>
 
 <!-- Commented out until we know what the heck to put here:
@@ -831,6 +833,53 @@ supported on all {{Window}} objects and <code><{body}></code> elements as attrib
     </tr>
   </tbody>
 </table>
+
+<h2 id="sa-heuristics-section">Storage Access Heuristics</h2>
+
+TODO: Storage access grant algo
+
+TODO: Constants
+
+TODO: This is what Chrome's doing
+
+<h3 id="sa-heuristics-popup">Popup Heuristic</h3>
+
+TODO: popup heuristic initiator host
+
+Append the following steps to the <a spec="html">activation notification</a>
+steps in the [[HTML#user-activation-processing-model|user activation processing
+model]]:
+
+1. Run [=detect a popup heuristic=] given <var ignore>document</var>.
+
+<div algorithm>
+
+To <dfn>detect a popup heuristic</dfn> given a [=Document=] |document|,
+perform the following steps:
+
+1. Let |navigable| be |document|'s [=node navigable=].
+1. If |navigable| is null, then abort these steps.
+1. If |navigable|'s [=popup heuristic initiator host=] is null,
+    then abort these steps.
+1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
+    [=navigable/active document=].
+1. Let |origin| be |topDocument|'s [=Document/origin=].
+1. If |origin| is an [=opaque origin=] then abort these steps.
+1. Let |site| be the result of running [=obtain a site=] given |origin|.
+1. Let |host| be |site|'s [=host=].
+1. [=Grant access for heuristics=] given:
+    <dl>
+        <dt><var ignore>host</var></dt>
+        <dd>|host|</dd>
+        <dt><var ignore>firstPartyHost</var></dt>
+        <dd>|navigable|'s [=popup heuristic initiator host=]</dd>
+        <dt><var ignore>duration</var></dt>
+        <dd>[=popup heuristic grant duration=]</dd>
+    </dl>
+
+</div>
+
+<h3 id="sa-heuristics-redirect">Redirect Heuristic</h3>
 
 <h2 id="ua-string-section">The User-Agent String</h2>
 

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -836,15 +836,58 @@ supported on all {{Window}} objects and <code><{body}></code> elements as attrib
 
 <h2 id="sa-heuristics-section">Storage Access Heuristics</h2>
 
-TODO: Storage access grant algo
+Browsers are working to deprecate third-party cookies while avoiding user-facing
+breakage by removing support for common web patterns, particularly login flows via
+third-party identity providers. Browsers can observe <code>Storage access heuristics</code>
+from the user in order to provide short-term storage access to unbreak these flows.
 
-TODO: Constants
+The following spec represents the Chromium implementation of this feature.
 
-TODO: This is what Chrome's doing
+<h3 id="sa-heuristics-constants">Constants</h3>
+
+The <dfn>popup heuristic grant duration</dfn> is an [=implementation-defined=]
+[=duration=] that represents the length of time after the popup heuristic is
+detected that the popup [=host=] will have access to the opener [=host=].
+
+Note: 30 days is a reasonable [=popup heuristic grant duration=] value.
+
+The <dfn>redirect heuristic grant duration</dfn> is an [=implementation-defined=]
+[=duration=] that represents the length of time after the redirect heuristic is
+detected that the bounced [=host=] will have access to the final [=host=].
+
+Note: 15 minutes is a reasonable [=redirect heuristic grant duration=] value.
+
+<h3 id="sa-heuristics-grant">Storage Access Grant</h3>
+
+<div algorithm>
+
+To <dfn>grant access for heuristics</dfn> given a [=host=] |host|, [=host=]
+|firstPartyHost|, and [=duration=] |duration|, perform the following steps:
+
+1. TODO
+1. |host|, |firstPartyHost|, |duration|
+
+</div>
 
 <h3 id="sa-heuristics-popup">Popup Heuristic</h3>
 
-TODO: popup heuristic initiator host
+Each [=top-level traversable=] has an associated
+<dfn for="top-level traversable">popup heuristic initiator host</dfn> which
+is a [=host=] or null. This stores the [=host=] of the <var ignore>opener</var> if
+[=top-level traversable=] is considered an eligible popup for the heuristic.
+
+Append the following steps to the <a spec="html">create a new top-level traversable</a>
+algorithm:
+1. TODO: Check opener access
+1. TODO: Check initiator iframe
+1. Let |popup heuristic initiator origin| be the <var ignore>opener</var>'s
+    [=browsing context/top-level traversable=]'s [=navigable/active document=]'s
+    [=Document/origin=].
+1. If |popup heuristic initiator origin| is an [=opaque origin=] then abort these steps.
+1. Let |popup heuristic initiator site| be the result of running [=obtain a site=] given
+    |popup heuristic initiator origin|.
+1. Set the [=top-level traversable=]'s [=popup heuristic initiator host=] to 
+    |popup heuristic initiator site|'s [=host=].
 
 Append the following steps to the <a spec="html">activation notification</a>
 steps in the [[HTML#user-activation-processing-model|user activation processing
@@ -880,6 +923,8 @@ perform the following steps:
 </div>
 
 <h3 id="sa-heuristics-redirect">Redirect Heuristic</h3>
+
+TODO
 
 <h2 id="ua-string-section">The User-Agent String</h2>
 


### PR DESCRIPTION
This is a prototype PR with my WIP changes to add 3PCD heuristics to the web compat spec. There are a few outstanding TODOs and several missing dfns, but beforehand I just wanted a sanity check on the structure of this section and its inclusion in this spec.

Explainer: https://github.com/amaliev/3pcd-exemption-heuristics/blob/main/explainer.md

Issue #254


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg_compat/253.html" title="Last updated on Nov 18, 2023, 2:48 PM UTC (8f64de8)">Preview</a> | <a href="https://whatpr.org/compat/253/30d5c35...8f64de8.html" title="Last updated on Nov 18, 2023, 2:48 PM UTC (8f64de8)">Diff</a>