### PR TITLE
Fix invalid character escape

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -699,7 +699,7 @@ effect.
 }
 </pre>
 
-The element <pre>&ltp class="stroked-text-longhand"&gt;Serious typography&lt;/p&gt;</pre> would be
+The element <pre>&lt;p class="stroked-text-longhand"&gt;Serious typography&lt;/p&gt;</pre> would be
 rendered as follows:
 
 <img width="381" height="116" src="stroked-text.png" alt="image of stroked text">


### PR DESCRIPTION
Bikeshed'll start complaining about this in the next release, since it's a parse error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/256.html" title="Last updated on Dec 8, 2023, 10:45 PM UTC (c08d977)">Preview</a> | <a href="https://whatpr.org/compat/256/30d5c35...c08d977.html" title="Last updated on Dec 8, 2023, 10:45 PM UTC (c08d977)">Diff</a>