### PR TITLE
Meta: fix border-bottom-* and border-top-* linking errors

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -58,6 +58,10 @@ urlPrefix: https://drafts.csswg.org/css-values-3/
 spec:css-animations-1; type:property; text:animation-delay
 spec:css-borders-4; type:property; text:box-shadow
 spec:css-borders-4; type:property; text:border-radius
+spec:css-borders-4; type:property; text:border-bottom-left-radius
+spec:css-borders-4; type:property; text:border-bottom-right-radius
+spec:css-borders-4; type:property; text:border-top-left-radius
+spec:css-borders-4; type:property; text:border-top-right-radius
 spec:css-conditional-3; type:at-rule; text:@media
 spec:css-display-3; type:value; for:display; text:flex
 spec:css-flexbox-1; type:value; text:inline-flex


### PR DESCRIPTION
Fixes #259


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/260.html" title="Last updated on Dec 18, 2023, 4:41 PM UTC (5830c71)">Preview</a> | <a href="https://whatpr.org/compat/260/57c7631...5830c71.html" title="Last updated on Dec 18, 2023, 4:41 PM UTC (5830c71)">Diff</a>