### PR TITLE
Meta: override default issue class to display GitHub issue links

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -935,7 +935,7 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/&lt;<a>majorVersion</a>&gt;.0.0.0
 
       "<code>Linux; Android 10; K</code>"<br>
       "<code>Windows NT 10.0; Win64; x64</code>"<br>
-      "<code>Macintosh; Intel Mac OS X 10_15_7"<br>
+      "<code>Macintosh; Intel Mac OS X 10_15_7"</code><br>
       "<code>X11; Linux x86_64</code>"<br>
       "<code>X11; CrOS x86_64 14541.0.0</code>"<br>
       "<code>Fuchsia</code>"<br>

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -591,7 +591,7 @@ the corresponding unprefixed keyword:
   </tbody>
 </table>
 
-Issue(87): These definitions of <code>-webkit-box-*</code> are known to not be web compatible.
+Issue(87): This definition of <code>-webkit-box</code> is known to not be web compatible.
 
 <h4 id="text-fill-and-stroking">Text Fill and Stroking</h4>
 

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -11,6 +11,7 @@ Indent: 2
 Markup Shorthands: dfn yes
 Issue Class: issue XXX
 Repository: whatwg/compat
+Issue Class: issue XXX
 </pre>
 
 <pre class="anchors">
@@ -46,7 +47,6 @@ spec:css-flexbox-1; type:value; text:inline-flex
 spec:css-syntax-3; type:dfn; text:invalid
 spec:filter-effects-1; type:property; text:filter
 spec:html; type:element; text:body
-spec:infra; type:dfn; text:string
 spec:infra; type:dfn; text:user agent
 spec:screen-orientation; type:dfn; text:current orientation angle
 spec:svg2; type:dfn; text:fill

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -914,7 +914,11 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/&lt;<a>majorVersion</a>&gt;.0.0.0
 
       "<code>Linux; Android 10; K</code>"<br>
       "<code>Windows NT 10.0; Win64; x64</code>"<br>
+<<<<<<< HEAD
       "<code>Macintosh; Intel Mac OS X 10_15_7</code>"<br>
+=======
+      "<code>Macintosh; Intel Mac OS X 10_15_7"</code><br>
+>>>>>>> 959ecb2 (Close an unclosed `code` tag.)
       "<code>X11; Linux x86_64</code>"<br>
       "<code>X11; CrOS x86_64 14541.0.0</code>"<br>
       "<code>Fuchsia</code>"<br>

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -123,8 +123,8 @@ of the corresponding unprefixed [=at-rules=]:
 
 <pre class='descdef mq'>
 Name: '-webkit-device-pixel-ratio'
-Value: <<number>>
 For: @media
+Value: <<number>>
 Type: range
 </pre>
 
@@ -160,8 +160,8 @@ The <code>min-</code> or <code>max-</code> [[mediaqueries-4#mq-min-max|prefixes 
 
 <pre class='descdef mq'>
 Name: '-webkit-transform-3d'
-Value: <<mq-boolean>>
 For: @media
+Value: <<mq-boolean>>
 Type: discrete
 </pre>
 
@@ -914,11 +914,7 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/&lt;<a>majorVersion</a>&gt;.0.0.0
 
       "<code>Linux; Android 10; K</code>"<br>
       "<code>Windows NT 10.0; Win64; x64</code>"<br>
-<<<<<<< HEAD
       "<code>Macintosh; Intel Mac OS X 10_15_7</code>"<br>
-=======
-      "<code>Macintosh; Intel Mac OS X 10_15_7"</code><br>
->>>>>>> 959ecb2 (Close an unclosed `code` tag.)
       "<code>X11; Linux x86_64</code>"<br>
       "<code>X11; CrOS x86_64 14541.0.0</code>"<br>
       "<code>Fuchsia</code>"<br>

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -11,7 +11,6 @@ Indent: 2
 Markup Shorthands: dfn yes
 Issue Class: issue XXX
 Repository: whatwg/compat
-Issue Class: issue XXX
 </pre>
 
 <pre class="anchors">
@@ -122,7 +121,7 @@ of the corresponding unprefixed [=at-rules=]:
 </h4>
 
 <pre class='descdef mq'>
-Name: '-webkit-device-pixel-ratio'
+Name: -webkit-device-pixel-ratio
 For: @media
 Value: <<number>>
 Type: range
@@ -159,7 +158,7 @@ The <code>min-</code> or <code>max-</code> [[mediaqueries-4#mq-min-max|prefixes 
 </h4>
 
 <pre class='descdef mq'>
-Name: '-webkit-transform-3d'
+Name: -webkit-transform-3d
 For: @media
 Value: <<mq-boolean>>
 Type: discrete

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -8,6 +8,7 @@ Abstract: This standard describes a collection of web platform features that web
 Translation: ja https://triple-underscore.github.io/compat-ja.html
 Indent: 2
 Markup Shorthands: dfn yes
+Issue Class: issue XXX
 </pre>
 
 <pre class="anchors">
@@ -67,6 +68,7 @@ spec:css-display-3; type:value; for:display; text:flex
 spec:css-flexbox-1; type:value; text:inline-flex
 spec:css-syntax-3; type:dfn; text:invalid
 spec:filter-effects-1; type:property; text:filter
+spec:html; type:element; text:body
 spec:infra; type:dfn; text:user agent
 spec:svg2; type:dfn; text:fill
 spec:svg2; type:dfn; text:stroke

--- a/compatibility.bs
+++ b/compatibility.bs
@@ -143,9 +143,9 @@ of the corresponding unprefixed [=at-rules=]:
 </h4>
 
 <pre class='descdef mq'>
-Name: '@media/-webkit-device-pixel-ratio'
-Value: <<number>>
+Name: '-webkit-device-pixel-ratio'
 For: @media
+Value: <<number>>
 Type: range
 </pre>
 
@@ -180,9 +180,9 @@ The <code>min-</code> or <code>max-</code> <a>prefixes on range features</a> mus
 </h4>
 
 <pre class='descdef mq'>
-Name: '@media/-webkit-transform-3d'
-Value: <<mq-boolean>>
+Name: '-webkit-transform-3d'
 For: @media
+Value: <<mq-boolean>>
 Type: discrete
 </pre>
 


### PR DESCRIPTION
Fixes #273


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/274.html" title="Last updated on Jul 24, 2025, 8:33 PM UTC (6dcf6f6)">Preview</a> | <a href="https://whatpr.org/compat/274/521d522...6dcf6f6.html" title="Last updated on Jul 24, 2025, 8:33 PM UTC (6dcf6f6)">Diff</a>