### PR TITLE
fix #279. Adds spaces in the UA pattern for Safari

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -973,7 +973,7 @@ On Firefox for Android, "<code>&lt;<a>platform</a>&gt;; &lt;<a for=firefox>devic
 <h4 id="ua-string-pattern-safari">Safari User-Agent pattern</h4>
 
 "<code>Mozilla/5.0 (&lt;<a>safariPlatform</a>&gt;) AppleWebKit/605.1.15 (KHTML, like Gecko)
-Version/&lt;<a>safariVersion</a>&gt;&lt;<a for="/">deviceCompat</a>&gt;Safari/&lt;<a>webkitVersion</a>&gt;</code>"
+Version/&lt;<a>safariVersion</a>&gt; &lt;<a for="/">deviceCompat</a>&gt; Safari/&lt;<a>webkitVersion</a>&gt;</code>"
 
 <div class="example" id="safari-ua-examples">
   <!-- https://github.com/WebKit/WebKit/blob/8427f75c2c505bbeac2898839e57c027f0bfccd8/Source/WebCore/platform/mac/UserAgentMac.mm -->


### PR DESCRIPTION
This fixes the pattern for Safari UA string, which was missing spaces. 