### PR TITLE
Fix markup

### DIFF
--- a/compatibility.bs
+++ b/compatibility.bs
@@ -845,8 +845,9 @@ This is a non-exhaustive list of common User-Agent <a>tokens</a>.
 
 <table>
   <thead>
-    <th>Tokens</th>
-    <th>Description</th>
+    <tr>
+      <th>Tokens</th>
+      <th>Description</th>
   </thead>
   <tbody>
     <tr>
@@ -906,8 +907,9 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/&lt;<a>majorVersion</a>&gt;.0.0.0
 
 <table>
   <thead>
-    <th>Tokens</th>
-    <th>Description</th>
+    <tr>
+      <th>Tokens</th>
+      <th>Description</th>
   </thead>
   <tbody>
     <tr>
@@ -959,8 +961,9 @@ On Firefox for Android, "<code>&lt;<a>platform</a>&gt;; &lt;<a for=firefox>devic
 
 <table>
   <thead>
-    <th>Tokens</th>
-    <th>Description</th>
+    <tr>
+      <th>Tokens</th>
+      <th>Description</th>
   </thead>
   <tbody>
     <tr><!-- TODO: consider documenting VR patterns -->
@@ -1007,8 +1010,9 @@ On mobile platforms, including smaller iPad form factors
 
 <table>
   <thead>
-    <th>Tokens</th>
-    <th>Description</th>
+    <tr>
+      <th>Tokens</th>
+      <th>Description</th>
   </thead>
   <tbody>
     <tr>


### PR DESCRIPTION
Missing <tr> in some tables. (This'll get caught by the upcoming major release of Bikeshed.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/286.html" title="Last updated on Dec 2, 2025, 9:26 PM UTC (2060d14)">Preview</a> | <a href="https://whatpr.org/compat/286/605ec4a...2060d14.html" title="Last updated on Dec 2, 2025, 9:26 PM UTC (2060d14)">Diff</a>