### PR TITLE
Review Draft Publication: December 2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
     - run: pip install bikeshed && bikeshed update
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!--
 Thank you for contributing to the Compatibility Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
+
+When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.
+
 If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
 -->
 

--- a/review-drafts/2025-12.bs
+++ b/review-drafts/2025-12.bs
@@ -1,5 +1,7 @@
 <pre class="metadata">
 Group: WHATWG
+Status: RD
+Date: 2025-12-15
 H1: Compatibility
 Shortname: compat
 Text Macro: TWITTER compatstandard


### PR DESCRIPTION
The [December 2025 Review Draft](https://compat.spec.whatwg.org/review-drafts/2025-12/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/compat/287.html" title="Last updated on Dec 15, 2025, 4:03 PM UTC (793abaf)">Preview</a> | <a href="https://whatpr.org/compat/287/f687c6a...793abaf.html" title="Last updated on Dec 15, 2025, 4:03 PM UTC (793abaf)">Diff</a>